### PR TITLE
[API-2078]: Update to latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 <dependency>
   <groupId>com.vertexvis</groupId>
   <artifactId>api-client-java</artifactId>
-  <version>0.2.5</version>
+  <version>0.2.6</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -25,13 +25,13 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 ### Gradle
 
 ```groovy
-compile "com.vertexvis:api-client-java:0.2.5"
+compile "com.vertexvis:api-client-java:0.2.6"
 ```
 
 ### Sbt
 
 ```sbt
-libraryDependencies += "com.vertexvis" % "api-client-java" % "0.2.5"
+libraryDependencies += "com.vertexvis" % "api-client-java" % "0.2.6"
 ```
 
 ### Others
@@ -44,7 +44,7 @@ mvn clean package
 
 Then manually install the following JARs.
 
-- `target/api-client-java-0.2.5.jar`
+- `target/api-client-java-0.2.6.jar`
 - `target/lib/*.jar`
 
 ## Usage

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7786,6 +7786,11 @@ components:
           items:
             $ref: '#/components/schemas/NonEmptyString'
           type: array
+        url:
+          example: some-string
+          maxLength: 1024
+          minLength: 1
+          type: string
       type: object
     UpdateWebhookSubscriptionRequest_data:
       properties:
@@ -8157,6 +8162,8 @@ components:
       type: object
     SceneViewStateData_attributes:
       properties:
+        camera:
+          $ref: '#/components/schemas/Camera'
         created:
           example: 2020-01-01T12:00:00Z
           format: date-time

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.vertexvis'
-version = '0.2.5'
+version = '0.2.6'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/vertexvis/ApiClient.java
+++ b/src/main/java/com/vertexvis/ApiClient.java
@@ -185,7 +185,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("vertex-api-client-java/0.2.5");
+        setUserAgent("vertex-api-client-java/0.2.6");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/vertexvis/model/SceneViewStateDataAttributes.java
+++ b/src/main/java/com/vertexvis/model/SceneViewStateDataAttributes.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.vertexvis.model.Camera;
 import com.vertexvis.model.ThumbnailData;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -33,6 +34,10 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class SceneViewStateDataAttributes {
+  public static final String SERIALIZED_NAME_CAMERA = "camera";
+  @SerializedName(SERIALIZED_NAME_CAMERA)
+  private Camera camera;
+
   public static final String SERIALIZED_NAME_CREATED = "created";
   @SerializedName(SERIALIZED_NAME_CREATED)
   private OffsetDateTime created;
@@ -44,6 +49,29 @@ public class SceneViewStateDataAttributes {
   public static final String SERIALIZED_NAME_THUMBNAILS = "thumbnails";
   @SerializedName(SERIALIZED_NAME_THUMBNAILS)
   private List<ThumbnailData> thumbnails = null;
+
+
+  public SceneViewStateDataAttributes camera(Camera camera) {
+    
+    this.camera = camera;
+    return this;
+  }
+
+   /**
+   * Get camera
+   * @return camera
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public Camera getCamera() {
+    return camera;
+  }
+
+
+  public void setCamera(Camera camera) {
+    this.camera = camera;
+  }
 
 
   public SceneViewStateDataAttributes created(OffsetDateTime created) {
@@ -132,20 +160,22 @@ public class SceneViewStateDataAttributes {
       return false;
     }
     SceneViewStateDataAttributes sceneViewStateDataAttributes = (SceneViewStateDataAttributes) o;
-    return Objects.equals(this.created, sceneViewStateDataAttributes.created) &&
+    return Objects.equals(this.camera, sceneViewStateDataAttributes.camera) &&
+        Objects.equals(this.created, sceneViewStateDataAttributes.created) &&
         Objects.equals(this.name, sceneViewStateDataAttributes.name) &&
         Objects.equals(this.thumbnails, sceneViewStateDataAttributes.thumbnails);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(created, name, thumbnails);
+    return Objects.hash(camera, created, name, thumbnails);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class SceneViewStateDataAttributes {\n");
+    sb.append("    camera: ").append(toIndentedString(camera)).append("\n");
     sb.append("    created: ").append(toIndentedString(created)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    thumbnails: ").append(toIndentedString(thumbnails)).append("\n");

--- a/src/main/java/com/vertexvis/model/UpdateWebhookSubscriptionRequestDataAttributes.java
+++ b/src/main/java/com/vertexvis/model/UpdateWebhookSubscriptionRequestDataAttributes.java
@@ -86,6 +86,10 @@ public class UpdateWebhookSubscriptionRequestDataAttributes {
   @SerializedName(SERIALIZED_NAME_TOPICS)
   private List<String> topics = null;
 
+  public static final String SERIALIZED_NAME_URL = "url";
+  @SerializedName(SERIALIZED_NAME_URL)
+  private String url;
+
 
   public UpdateWebhookSubscriptionRequestDataAttributes status(StatusEnum status) {
     
@@ -141,6 +145,29 @@ public class UpdateWebhookSubscriptionRequestDataAttributes {
   }
 
 
+  public UpdateWebhookSubscriptionRequestDataAttributes url(String url) {
+    
+    this.url = url;
+    return this;
+  }
+
+   /**
+   * Get url
+   * @return url
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(example = "some-string", value = "")
+
+  public String getUrl() {
+    return url;
+  }
+
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -151,12 +178,13 @@ public class UpdateWebhookSubscriptionRequestDataAttributes {
     }
     UpdateWebhookSubscriptionRequestDataAttributes updateWebhookSubscriptionRequestDataAttributes = (UpdateWebhookSubscriptionRequestDataAttributes) o;
     return Objects.equals(this.status, updateWebhookSubscriptionRequestDataAttributes.status) &&
-        Objects.equals(this.topics, updateWebhookSubscriptionRequestDataAttributes.topics);
+        Objects.equals(this.topics, updateWebhookSubscriptionRequestDataAttributes.topics) &&
+        Objects.equals(this.url, updateWebhookSubscriptionRequestDataAttributes.url);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, topics);
+    return Objects.hash(status, topics, url);
   }
 
   @Override
@@ -165,6 +193,7 @@ public class UpdateWebhookSubscriptionRequestDataAttributes {
     sb.append("class UpdateWebhookSubscriptionRequestDataAttributes {\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    topics: ").append(toIndentedString(topics)).append("\n");
+    sb.append("    url: ").append(toIndentedString(url)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

@MadisonEhlers-Vertex @jdm717 @danconner-vertex This adds the camera to the scene-view-state response bodies so you should be able to fly to the camera, wait for the animation to complete, and then load the scene-view-state. This is what the work-instructions demo does. It's also added the node client in version `0.14.2`.

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

* Add `camera` to `GET /scene-view-staate/:id` and `GET /scenes/:id/scene-view-states` response bodies.
* Add ability to update `webhook-subscription` `url` on `PATCH`.

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->