### PR TITLE
[PLAT-2646] Use Node 16 in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with: { java-version: 17, distribution: temurin }
       - name: Build and Verify
         run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       publish: ${{ steps.detect-publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: detect-publish
         run: |
           result=$(./scripts/detect-publish.sh)
@@ -20,8 +20,8 @@ jobs:
     needs: [detect-publish]
     if: needs.detect-publish.outputs.publish == 1
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with: { java-version: 17, distribution: temurin }
       - name: Publish
         env:


### PR DESCRIPTION
## Summary
The Github actions used in this service were running on Node 12 and Github is going to turn off support for Node 12 soon. Therefore, this updates the Github actions to use Node 16.

## Test Plan
Verify the service can be built and published

## Release Notes
None

## Possible Regressions
Building and publishing service

## Dependencies
None