### PR TITLE
PLAT-5219: Better retries with concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 <dependency>
   <groupId>com.vertexvis</groupId>
   <artifactId>api-client-java</artifactId>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -25,13 +25,13 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 ### Gradle
 
 ```groovy
-compile "com.vertexvis:api-client-java:0.8.2"
+compile "com.vertexvis:api-client-java:0.8.3"
 ```
 
 ### Sbt
 
 ```sbt
-libraryDependencies += "com.vertexvis" % "api-client-java" % "0.8.2"
+libraryDependencies += "com.vertexvis" % "api-client-java" % "0.8.3"
 ```
 
 ### Others
@@ -44,7 +44,7 @@ mvn clean package
 
 Then manually install the following JARs.
 
-- `target/api-client-java-0.8.2.jar`
+- `target/api-client-java-0.8.3.jar`
 - `target/lib/*.jar`
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.vertexvis'
-version = '0.8.2'
+version = '0.8.3'
 
 repositories {
     mavenCentral()
@@ -76,19 +76,20 @@ javadoc {
 }
 
 dependencies {
-    implementation 'io.swagger:swagger-annotations:1.6.3'
+    implementation 'io.swagger:swagger-annotations:1.6.14'
     implementation "com.google.code.findbugs:jsr305:3.0.2"
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-    implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'io.gsonfire:gson-fire:1.8.5'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'io.gsonfire:gson-fire:1.9.0'
     implementation 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.1' // 1.0.2 doesn't work with okkhttp3
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.2'
-    implementation 'info.picocli:picocli:4.7.0'
-    testImplementation(platform('org.junit:junit-bom:5.8.2'))
-    testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
+    implementation 'org.apache.commons:commons-lang3:3.15.0'
+    implementation 'javax.annotation:javax.annotation-api:1.3'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
+    implementation 'info.picocli:picocli:4.7.6'
+    testImplementation(platform('org.junit:junit-bom:5.10.3'))
+    testImplementation('org.junit.jupiter:junit-jupiter:5.10.3')
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 test {

--- a/src/main/java/com/vertexvis/ApiClient.java
+++ b/src/main/java/com/vertexvis/ApiClient.java
@@ -207,7 +207,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("vertex-api-client-java/0.8.1");
+        setUserAgent("vertex-api-client-java/0.8.3");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/vertexvis/auth/OAuthOkHttpClient.java
+++ b/src/main/java/com/vertexvis/auth/OAuthOkHttpClient.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 public class OAuthOkHttpClient implements HttpClient {
-    private OkHttpClient client;
+    private final OkHttpClient client;
 
     public OAuthOkHttpClient() {
         this.client = new OkHttpClient();

--- a/src/test/java/com/vertexvis/auth/RetryingOAuthTest.java
+++ b/src/test/java/com/vertexvis/auth/RetryingOAuthTest.java
@@ -1,0 +1,79 @@
+package com.vertexvis.auth;
+
+import com.vertexvis.ApiClient;
+import com.vertexvis.ApiException;
+import com.vertexvis.api.PartRevisionsApi;
+import okhttp3.Call;
+import okhttp3.Request;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RetryingOAuthTest {
+    final static int numThreads = 10;
+    private static void startServer(MockWebServer server) throws IOException {
+        server.setDispatcher(new Dispatcher()
+        {
+            static final AtomicInteger numCalls = new AtomicInteger();
+
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) throws InterruptedException {
+                Thread.sleep(200);
+                var token = numCalls.incrementAndGet() > (numThreads / 2) ? "1" : "0";
+                if (Objects.equals(recordedRequest.getPath(), "/oauth2/token")) {
+                    return new MockResponse().addHeader("Content-Type", "application/json").setBody("{\"access_token\": \"" + token + "\"}");
+                }
+                if (!recordedRequest.getHeaders().get("Authorization").endsWith(token)) {
+                    return new MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED).setBody("{\"error\": \"invalid_token\"}");
+                }
+                return new MockResponse().setBody("{\"data\": {\"id\": \"" + UUID.randomUUID().toString() + "\"}}");
+            }
+        });
+        server.start();
+    }
+
+    @Test
+    public void multithreading() throws ApiException, IOException {
+        final AtomicInteger numFails = new AtomicInteger();
+        try (var server = new MockWebServer()) {
+            startServer(server);
+
+            final String baseUrl = server.url("/api").toString();
+            var client = new ApiClient(baseUrl, "clientid", "clientsecret", new HashMap<>());
+            var prs = new PartRevisionsApi(client);
+            Thread[] threads = new Thread[numThreads];
+            for (var i = 0; i < numThreads; i++) {
+                threads[i] = new Thread(() -> {
+                    try {
+                        prs.deletePartRevision(UUID.randomUUID());
+                    } catch (Exception e) {
+                        numFails.incrementAndGet();
+                    }
+                });
+               threads[i].start();
+            }
+
+            for (var i = 0; i < numThreads; i++) {
+                threads[i].join();
+            }
+
+            Assertions.assertEquals(0, numFails.get());
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary
Previously, if two or more threads completed with 401/403 errors concurrently before the `updateAccessToken` happened, only one of them would be retried.

Now, they'll all be retried. That multiple requests have to be retried due to the same expired token is an unavoidable side-effect of the fact that we allow multiple concurrent requests (and that we only know that the token is expired as a result from the request itself), and we can live with that tradeoff.

Also, updated dependencies and cleaned up a little bit of code.

[PLAT-5219](https://vertexvis.atlassian.net/browse/PLAT-5219)

## Test Plan
After this is incorporated into the PLM integration kernel, do some transfers that take more than 1 hour in order to experience an expired token. There should be no failures due to these expirations.


[PLAT-5219]: https://vertexvis.atlassian.net/browse/PLAT-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ