### PR TITLE
Update to user tokens

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
           ./gradlew \
             -P signingKey=${{ secrets.ORG_GRADLE_PROJECT_signingKey }} \
             -P signingPassword=${{ secrets.ORG_GRADLE_PROJECT_signingPassword }} \
-            -P sonatypeUsername=${{ secrets.SONATYPE_USERNAME }} \
-            -P sonatypePassword=${{ secrets.SONATYPE_PASSWORD }} \
+            -P ossrhUsername=${{ secrets.OSSRH_USERNAME }} \
+            -P ossrhPassword=${{ secrets.OSSRH_PASSWORD }} \
             publishToSonatype \
             closeAndReleaseSonatypeStagingRepository
           ./scripts/publish.sh


### PR DESCRIPTION
## Summary
Per https://central.sonatype.org/news/20240301_changes_to_account_management/#new-publishers-who-will-be-publishing-via-ossrh (and because we got a 401 error publishing the old way), we now have to use user tokens to publish.

I followed the instructions here: https://central.sonatype.org/publish/generate-token/ and generated a token username/password pair, which I added to the 1Password entry for Sonatype, and to Github actions secrets.

I think this yml update will cause the publish action to use the new things.
