### PR TITLE
[PLAT-5255] Add missing AnyOf and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 <dependency>
   <groupId>com.vertexvis</groupId>
   <artifactId>api-client-java</artifactId>
-  <version>0.8.3</version>
+  <version>0.8.5</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -25,13 +25,13 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 ### Gradle
 
 ```groovy
-compile "com.vertexvis:api-client-java:0.8.3"
+compile "com.vertexvis:api-client-java:0.8.5"
 ```
 
 ### Sbt
 
 ```sbt
-libraryDependencies += "com.vertexvis" % "api-client-java" % "0.8.3"
+libraryDependencies += "com.vertexvis" % "api-client-java" % "0.8.5"
 ```
 
 ### Others
@@ -44,7 +44,7 @@ mvn clean package
 
 Then manually install the following JARs.
 
-- `target/api-client-java-0.8.3.jar`
+- `target/api-client-java-0.8.5.jar`
 - `target/lib/*.jar`
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.vertexvis'
-version = '0.8.4'
+version = '0.8.5'
 
 repositories {
     mavenCentral()

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -28,7 +28,8 @@ main() {
                 AnyOfFileRelationshipPartAssemblyRelationship.java \
                 AnyOfPropertySetRelationshipPartRevisionRelationshipSceneItemRelationshipPartInstanceRelationship.java \
                 OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType.java \
-                AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.java)
+                AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject.java \
+                AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.java )
   mv "src/test" . || true
   for f in "${root[@]}"; do mv "src/main/java/com/vertexvis/$f" . || true; done
   for f in "${auth[@]}"; do mv "src/main/java/com/vertexvis/auth/$f" . || true; done

--- a/src/main/java/com/vertexvis/ApiClient.java
+++ b/src/main/java/com/vertexvis/ApiClient.java
@@ -207,7 +207,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("vertex-api-client-java/0.8.4");
+        setUserAgent("vertex-api-client-java/0.8.5");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/vertexvis/auth/OAuthOkHttpClient.java
+++ b/src/main/java/com/vertexvis/auth/OAuthOkHttpClient.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 public class OAuthOkHttpClient implements HttpClient {
-    private final OkHttpClient client;
+    private OkHttpClient client;
 
     public OAuthOkHttpClient() {
         this.client = new OkHttpClient();

--- a/src/main/java/com/vertexvis/model/AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.java
+++ b/src/main/java/com/vertexvis/model/AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.java
@@ -1,0 +1,69 @@
+package com.vertexvis.model;
+
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
+public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType {
+    private PropertyStringType stringType= null;
+    private PropertyDoubleType doubleType= null;
+    private PropertyLongType longType= null;
+    private PropertyDateType dateType= null;
+
+    public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(PropertyStringType stringType) {
+        this.stringType= stringType;
+    }
+
+    public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(PropertyDoubleType doubleType) {
+        this.doubleType= doubleType;
+    }
+
+    public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(PropertyLongType longType) {
+        this.longType= longType;
+    }
+
+    public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(PropertyDateType dateType) {
+        this.dateType= dateType;
+    }
+
+    public Object getPropertyObject() {
+        if (stringType != null) {
+            return stringType;
+        } else if (doubleType != null) {
+            return doubleType;
+        } else if (longType != null) {
+            return longType;
+        }
+        return dateType;
+    }
+
+    public boolean isPropertyStringType() {
+        return stringType != null;
+    }
+
+    public boolean isPropertyDoubleType() {
+        return doubleType != null;
+    }
+
+    public boolean isPropertyLongType() {
+        return longType != null;
+    }
+
+    public boolean isPropertyDateType() {
+        return dateType != null;
+    }
+
+    public PropertyStringType getPropertyStringType() {
+        return stringType;
+    }
+
+    public PropertyDoubleType getPropertyDoubleType()  {
+        return doubleType;
+    }
+
+    public PropertyLongType getPropertyLongType(){
+        return longType;
+    }
+
+    public PropertyDateType getPropertyDateType() {
+        return dateType;
+    }
+}
+

--- a/src/main/java/com/vertexvis/model/PropertyEntryDataAttributes.java
+++ b/src/main/java/com/vertexvis/model/PropertyEntryDataAttributes.java
@@ -14,9 +14,16 @@
 package com.vertexvis.model;
 
 import java.util.Objects;
-
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.vertexvis.model.PropertyKeyType;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.io.IOException;
 
 /**
  * PropertyEntryDataAttributes
@@ -25,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
 public class PropertyEntryDataAttributes {
   public static final String SERIALIZED_NAME_VALUE = "value";
   @SerializedName(SERIALIZED_NAME_VALUE)
-  private AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject value;
+  private AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType value;
 
   public static final String SERIALIZED_NAME_KEY = "key";
   @SerializedName(SERIALIZED_NAME_KEY)
@@ -34,7 +41,7 @@ public class PropertyEntryDataAttributes {
   public PropertyEntryDataAttributes() { 
   }
 
-  public PropertyEntryDataAttributes value(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject value) {
+  public PropertyEntryDataAttributes value(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType value) {
     
     this.value = value;
     return this;
@@ -47,12 +54,12 @@ public class PropertyEntryDataAttributes {
   @javax.annotation.Nullable
   @ApiModelProperty(required = true, value = "")
 
-  public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject getValue() {
+  public AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType getValue() {
     return value;
   }
 
 
-  public void setValue(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject value) {
+  public void setValue(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType value) {
     this.value = value;
   }
 

--- a/src/test/java/com/vertexvis/model/AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeTest.java
+++ b/src/test/java/com/vertexvis/model/AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeTest.java
@@ -8,13 +8,13 @@ import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobjectTest {
+public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeTest {
 
     @Test
     void deserializePropertyStringType() {
         String input = "{\"stringType\":{\"type\":\"string\",\"value\":\"some-value\"}}";
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf=
-            new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject.class).getType());
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf=
+            new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.class).getType());
 
         assertTrue(anyOf.isPropertyStringType());
         PropertyStringType property= anyOf.getPropertyStringType();
@@ -30,8 +30,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
         property.setType(PropertyStringType.TypeEnum.STRING);
         property.setValue("some-value");
 
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf =
-                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject(property);
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf =
+                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(property);
 
         String expected = "{\"stringType\":{\"type\":\"string\",\"value\":\"some-value\"}}";
         assertEquals(expected, new JSON().serialize(anyOf));
@@ -40,8 +40,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
     @Test
     void deserializePropertyDoubleType() {
         String input = "{\"doubleType\":{\"type\":\"double\",\"value\":1234.5678}}";
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf=
-                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject.class).getType());
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf=
+                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.class).getType());
 
         assertTrue(anyOf.isPropertyDoubleType());
         PropertyDoubleType property= anyOf.getPropertyDoubleType();
@@ -57,8 +57,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
         property.setType(PropertyDoubleType.TypeEnum.DOUBLE);
         property.setValue(1234.5678);
 
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf =
-                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject(property);
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf =
+                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(property);
 
         String expected = "{\"doubleType\":{\"type\":\"double\",\"value\":1234.5678}}";
 
@@ -68,8 +68,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
     @Test
     void deserializePropertyLongType() {
         String input = "{\"longType\":{\"type\":\"long\",\"value\":1234}}";
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf=
-                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject.class).getType());
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf=
+                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.class).getType());
 
         assertTrue(anyOf.isPropertyLongType());
         PropertyLongType property= anyOf.getPropertyLongType();
@@ -85,8 +85,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
         property.setType(PropertyLongType.TypeEnum.LONG);
         property.setValue(1234L);
 
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf =
-                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject(property);
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf =
+                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(property);
 
         String expected = "{\"longType\":{\"type\":\"long\",\"value\":1234}}";
 
@@ -96,8 +96,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
     @Test
     void deserializePropertyDateType() {
         String input = "{\"dateType\":{\"type\":\"date\",\"value\":\"2025-02-13T11:45:10.123-05:00\"}}";
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf=
-                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject.class).getType());
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf=
+                new JSON().deserialize(input, TypeToken.get(AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType.class).getType());
 
         assertTrue(anyOf.isPropertyDateType());
         PropertyDateType property= anyOf.getPropertyDateType();
@@ -114,8 +114,8 @@ public class AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDa
         String date= OffsetDateTime.now().toString();
         property.setValue(OffsetDateTime.parse("2025-02-13T11:45:10.123-05:00"));
 
-        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject anyOf =
-                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject(property);
+        AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType anyOf =
+                new AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType(property);
 
         String expected = "{\"dateType\":{\"type\":\"date\",\"value\":\"2025-02-13T11:45:10.123-05:00\"}}";
 

--- a/src/test/java/com/vertexvis/model/OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataTypeTest.java
+++ b/src/test/java/com/vertexvis/model/OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataTypeTest.java
@@ -1,0 +1,84 @@
+package com.vertexvis.model;
+
+import com.google.gson.reflect.TypeToken;
+import com.vertexvis.JSON;
+import io.swagger.annotations.ApiModelProperty;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataTypeTest {
+
+    @Test
+    void deserializeSceneAnnotationCalloutDataType() {
+        String input = "{\"calloutType\":{\"type\":\"callout\",\"position\":{\"x\":1,\"y\":2,\"z\":3},\"icon\":\"comment-show\",\"primaryColor\":\"#FFFF00\",\"accentColor\":\"#FF00FF\"}}";
+        OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType oneOf=
+                new JSON().deserialize(input, TypeToken.get(OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType.class).getType());
+
+        SceneAnnotationCalloutDataType annotation= oneOf.getSceneAnnotationCalloutDataType();
+        assertNotNull(annotation);
+        assertEquals(annotation.getType(), "callout");
+        Vector3 position= new Vector3();
+        position.setX(new BigDecimal(1.0));
+        position.setY(new BigDecimal(2.0));
+        position.setZ(new BigDecimal(3.0));
+        assertEquals(annotation.getPosition(), position);
+        assertEquals(annotation.getIcon(), "comment-show");
+        assertEquals(annotation.getPrimaryColor(),"#FFFF00");
+        assertEquals(annotation.getAccentColor(), "#FF00FF");
+    }
+
+    @Test
+    void serializeSceneAnnotationCalloutDataType() {
+        SceneAnnotationCalloutDataType annotation = new SceneAnnotationCalloutDataType();
+
+        annotation.setType("callout");
+        Vector3 position= new Vector3();
+        position.setX(new BigDecimal(1.0));
+        position.setY(new BigDecimal(2.0));
+        position.setZ(new BigDecimal(3.0));
+        annotation.setPosition(position);
+        annotation.setIcon("comment-show");
+        annotation.setPrimaryColor("#FFFF00");
+        annotation.setAccentColor("#FF00FF");
+
+        OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType oneOf =
+                new OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType(annotation);
+
+        String expected = "{\"calloutType\":{\"type\":\"callout\",\"position\":{\"x\":1,\"y\":2,\"z\":3},\"icon\":\"comment-show\",\"primaryColor\":\"#FFFF00\",\"accentColor\":\"#FF00FF\"}}";
+
+        assertEquals(expected, new JSON().serialize(oneOf));
+    }
+
+    @Test
+    void deserializeSceneAnnotationCustomDataType() {
+        String input = "{\"customType\":{\"type\":\"custom\",\"jsonType\":\"my-annotation-type\",\"json\":\"{\\\"label\\\":\\\"my annotation\\\",\\\"anchor\\\":{\\\"x\\\":0,\\\"y\\\":0,\\\"z\\\":0}}\"}}";
+        OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType oneOf =
+                new JSON().deserialize(input, TypeToken.get(OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType.class).getType());
+
+        SceneAnnotationCustomDataType annotation= oneOf.getSceneAnnotationCustomDataType();
+        assertNotNull(annotation);
+        assertEquals(annotation.getType(), "custom");
+        assertEquals(annotation.getJsonType(), "my-annotation-type");
+        assertEquals(annotation.getJson(), "{\"label\":\"my annotation\",\"anchor\":{\"x\":0,\"y\":0,\"z\":0}}");
+    }
+
+    @Test
+    void serializeSceneAnnotationCustomDataType() {
+        SceneAnnotationCustomDataType annotation = new SceneAnnotationCustomDataType();
+
+        annotation.setType("custom");
+        annotation.setJsonType("my-annotation-type");
+        annotation.setJson("{\"label\":\"my annotation\",\"anchor\":{\"x\":0,\"y\":0,\"z\":0}}");
+
+        OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType oneOf =
+                new OneOfSceneAnnotationCalloutDataTypeSceneAnnotationCustomDataType(annotation);
+
+        String expected = "{\"customType\":{\"type\":\"custom\",\"jsonType\":\"my-annotation-type\",\"json\":\"{\\\"label\\\":\\\"my annotation\\\",\\\"anchor\\\":{\\\"x\\\":0,\\\"y\\\":0,\\\"z\\\":0}}\"}}";
+
+        assertEquals(expected, new JSON().serialize(oneOf));
+    }
+
+}


### PR DESCRIPTION
## Summary
The adds a identical AnyOf class :
AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateType

This is identical to but the usage is different so OpenAPI is referencing different classes:
AnyOfPropertyStringTypePropertyDoubleTypePropertyLongTypePropertyDateTypeobject

One is used / reference in  PropertyEntryData.yml.yml  and one UpsertPropertyEntriesRequest.yml

**This also bumps the version to 0.8.5 which was missed in the last PR.**

## Test Plan
Unit test generated

## Release Notes
None

## Possible Regressions
None expected

