### PR TITLE
PLAT-8098: Bump version to include latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 <dependency>
   <groupId>com.vertexvis</groupId>
   <artifactId>api-client-java</artifactId>
-  <version>0.17.0</version>
+  <version>0.18.0</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -25,13 +25,13 @@ The client can be used with Java 1.8+ and pulled into Maven or Gradle projects.
 ### Gradle
 
 ```groovy
-compile "com.vertexvis:api-client-java:0.17.0"
+compile "com.vertexvis:api-client-java:0.18.0"
 ```
 
 ### Sbt
 
 ```sbt
-libraryDependencies += "com.vertexvis" % "api-client-java" % "0.17.0"
+libraryDependencies += "com.vertexvis" % "api-client-java" % "0.18.0"
 ```
 
 ### Others
@@ -44,7 +44,7 @@ mvn clean package
 
 Then manually install the following JARs.
 
-- `target/api-client-java-0.17.0.jar`
+- `target/api-client-java-0.18.0.jar`
 - `target/lib/*.jar`
 
 ## Usage
@@ -104,7 +104,7 @@ To consume published snapshot versions in other projects, add the snapshot repos
 <dependency>
   <groupId>com.vertexvis</groupId>
   <artifactId>api-client-java</artifactId>
-  <version>0.17.0-SNAPSHOT</version>
+  <version>0.18.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -119,7 +119,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.vertexvis:api-client-java:0.17.0-SNAPSHOT'
+    implementation 'com.vertexvis:api-client-java:0.18.0-SNAPSHOT'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin"
 }
 
-def projectVersion = '0.17.0'
+def projectVersion = '0.18.0'
 def isSnapshot = project.hasProperty('isSnapshot') && project.isSnapshot.toBoolean()
 version = isSnapshot ? "${projectVersion}-SNAPSHOT" : projectVersion
 


### PR DESCRIPTION
## Summary
This pulls in the file collection patch schema fixes. The patch endpoint schema was declared as returning a 204 (no content) but returning data.  

## Test Plan
Validate the generated code has something like this:

```
    /**
     * 
     * Update a &#x60;file-collection&#x60;.
     * @param id The &#x60;file-collection&#x60; ID. (required)
     * @param updateFileCollectionRequest  (required)
     * @return ApiResponse&lt;FileCollectionMetadata&gt;
     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
     * @http.response.details
     <table border="1">
       <caption>Response Details</caption>
        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
        <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
     </table>
     */
    public ApiResponse<FileCollectionMetadata> updateFileCollectionWithHttpInfo(@javax.annotation.Nonnull UUID id, @javax.annotation.Nonnull UpdateFileCollectionRequest updateFileCollectionRequest) throws ApiException {
        okhttp3.Call localVarCall = updateFileCollectionValidateBeforeCall(id, updateFileCollectionRequest, null);
        Type localVarReturnType = new TypeToken<FileCollectionMetadata>(){}.getType();
        return localVarApiClient.execute(localVarCall, localVarReturnType);
    }
```
